### PR TITLE
[FEAT] 회원 탈퇴로 인한 서비스 전파

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# ---- Build stage ----
+FROM gradle:8.7-jdk17 AS build
+WORKDIR /workspace
+COPY build.gradle settings.gradle ./
+COPY gradle/ gradle/
+RUN gradle --no-daemon dependencies
+COPY src/ src/
+RUN gradle --no-daemon clean bootJar -x test
+
+# ---- Runtime stage ----
+FROM eclipse-temurin:17-jre-jammy
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+RUN useradd -ms /bin/bash appuser
+WORKDIR /app
+ARG JAR_FILE=build/libs/*.jar
+COPY --from=build /workspace/${JAR_FILE} app.jar
+USER appuser
+EXPOSE 8080
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+  CMD curl -fsS http://localhost:8080/actuator/health || exit 1
+ENTRYPOINT ["java","-XX:MaxRAMPercentage=75.0","-XX:+UseG1GC","-XX:+UseStringDeduplication","-Djava.security.egd=file:/dev/./urandom","-jar","app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
 
+    //resilience4j
+    implementation platform("io.github.resilience4j:resilience4j-bom:2.2.0") // 버전 한줄로 관리
+    implementation "io.github.resilience4j:resilience4j-spring-boot3"       // ★ 필수 (Registry/AutoConfig)
+    implementation "org.springframework.boot:spring-boot-starter-aop"   // 필수
+
     // Kafka
     implementation 'org.springframework.kafka:spring-kafka'
 

--- a/src/main/java/com/project/saga/SagaOrchestrationServiceApplication.java
+++ b/src/main/java/com/project/saga/SagaOrchestrationServiceApplication.java
@@ -2,8 +2,14 @@ package com.project.saga;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
+@EnableJpaAuditing
+@EnableScheduling
 public class SagaOrchestrationServiceApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/project/saga/domain/domain/entity/OutboxEvent.java
+++ b/src/main/java/com/project/saga/domain/domain/entity/OutboxEvent.java
@@ -1,0 +1,97 @@
+package com.project.saga.domain.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.*;
+
+/**
+ * Outbox 패턴용 이벤트 레코드.
+ *
+ * - 오케스트레이션 서비스는 도메인 트랜잭션 안에서 이 엔티티를 INSERT만 한다.
+ * - 별도 배경 스케줄러(OutboxPublisher)가 READY 상태의 레코드를 잠금으로 집어와
+ *   Kafka 로 전송 후 SENT 로 마킹한다.
+ * - 전송 실패 시 backoff 를 적용하여 일정 시간 뒤 재시도한다.
+ *
+ * 운영 인덱스 권장:
+ *   CREATE INDEX idx_outbox_ready_next ON outbox_event(status, next_attempt_at, id);
+ *   CREATE UNIQUE INDEX ux_outbox_event ON outbox_event(event_id, event_type);
+ */
+@Entity
+@Table(name = "outbox_event")
+@Getter @NoArgsConstructor
+public class OutboxEvent {
+
+    public enum Status { READY, SENT, FAILED } // FAILED 는(필요 시) 수동 조사를 위해 유지
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** 사가의 상관키(correlation) → 이번 설계에서는 sagaId 와 동일 */
+    @Column(nullable=false, length=36)
+    private String eventId;
+
+    /** 이벤트가 속한 애그리게이트 타입(모니터링/검색용) */
+    @Column(nullable=false, length=64)
+    private String aggregateType;     // "User"
+
+    /** 애그리게이트 식별자(파티셔닝 키와도 동일 케이스가 많음) */
+    @Column(nullable=false)
+    private Long aggregateId;         // userNo
+
+    /** 전송할 이벤트 종류(→ 카프카 토픽 매핑에 사용) */
+    @Column(nullable=false, length=64)
+    private String eventType;         // AUTH_REVOKE | SLEEP_DELETE | SLEEP_COMPENSATE | USER_FINAL_DELETE
+
+    /** 브로커로 흘려보낼 JSON 페이로드 (RDB에서는 단순 문자열로 보관) */
+    @Column(nullable=false, columnDefinition="json")
+    private String payload;
+
+    /** 카프카 파티셔닝 키(동일 유저 이벤트 순서 보장을 위해 userNo 문자열 사용) */
+    @Column(nullable=false, length=128)
+    private String partitionKey;      // userNo 문자열
+
+    /** 준비됨 → 전송됨 → (실패 시) 재시도 대기/실패 마킹 */
+    @Enumerated(EnumType.STRING)
+    @Column(nullable=false, length=16)
+    private Status status = Status.READY;
+
+    /** 누적 전송 시도 횟수(지수 백오프 계산에 사용) */
+    @Column(nullable=false)
+    private Integer attempts = 0;
+
+    /** 생성 시간(UTC, 하이버네이트가 자동 세팅) */
+    @org.hibernate.annotations.CreationTimestamp
+    @Column(nullable=false, updatable=false)
+    private Instant createdAt;
+
+    /** 다음 재시도 시각(UTC). 전송 성공 시엔 의미 없음 */
+    @Column(nullable=false)
+    private Instant nextAttemptAt = Instant.now();
+
+    /** 실제 브로커 전송 성공 시간(모니터링용) */
+    private Instant processedAt;
+
+    /** 팩토리 메서드: 필요한 필드만 받아 간결하게 생성 */
+    public static OutboxEvent of(String eventId, String aggType, Long aggId,
+                                 String eventType, String payload, String partitionKey){
+        OutboxEvent e = new OutboxEvent();
+        e.eventId = eventId; e.aggregateType = aggType; e.aggregateId = aggId;
+        e.eventType = eventType; e.payload = payload; e.partitionKey = partitionKey;
+        return e;
+    }
+
+    /** 전송 성공 마킹(상태 전이 + 타임스탬프 기록) */
+    public void markSent(){ this.status = Status.SENT; this.processedAt = Instant.now(); }
+
+    /**
+     * 전송 실패 시 backoff 적용:
+     * - attempts 증가
+     * - nextAttemptAt 을 현재+지연 으로 갱신
+     * - 상태는 READY 로 유지 → 퍼블리셔가 다음 턴에 다시 집어가게 함
+     */
+    public void failAndBackoff(Duration d){
+        this.attempts = this.attempts + 1;
+        this.nextAttemptAt = Instant.now().plus(d);
+        this.status = Status.READY; // 재시도 대기
+    }
+}

--- a/src/main/java/com/project/saga/domain/domain/entity/UserDeletionSaga.java
+++ b/src/main/java/com/project/saga/domain/domain/entity/UserDeletionSaga.java
@@ -1,0 +1,59 @@
+package com.project.saga.domain.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.Instant;
+
+/**
+ * 유저 삭제 사가의 진행 상태를 추적하는 엔티티.
+ *
+ * - 상태 머신: IN_PROGRESS → (COMPENSATING | COMPLETED | FAILED | COMPENSATED)
+ * - 각 하위 단계의 완료 여부(tokenOk/sleepOk/userOk)를 플래그로 기록
+ * - @CreationTimestamp/@UpdateTimestamp 로 UTC 타임스탬프 자동 관리
+ * - 낙관적 락(@Version)으로 동시 업데이트 충돌을 방지
+ */
+@Entity
+@Table(name = "user_deletion_saga")
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class UserDeletionSaga {
+
+    public enum SagaStatus { IN_PROGRESS, COMPENSATING, COMPLETED, COMPENSATED, FAILED }
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** 삭제 대상 사용자 */
+    @Column(nullable=false)
+    private Long userNo;
+
+    /** 이 사가 인스턴스를 식별하는 correlationId(= 각 커맨드 eventId) */
+    @Column(nullable=false, length=36, unique=true)
+    private String sagaId;
+
+    /** 사가 상태(빌더 기본값 보존을 위해 @Builder.Default 적용) */
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    @Column(nullable=false, length=16)
+    private SagaStatus status = SagaStatus.IN_PROGRESS;
+
+    /** 하위 스텝 진행 여부(멱등/재처리에 대비하여 별도 기록) */
+    @Builder.Default @Column(nullable=false) private boolean tokenOk = false;  // 토큰 폐기는 보상 없음
+    @Builder.Default @Column(nullable=false) private boolean sleepOk = false;  // 슬립 삭제 성공 여부
+    @Builder.Default @Column(nullable=false) private boolean userOk  = false;  // 유저 최종 삭제 성공 여부
+
+    /** 사가 시작/갱신 시간(UTC, 하이버네이트가 자동 세팅) */
+    @org.hibernate.annotations.CreationTimestamp
+    @Column(nullable=false, updatable=false)
+    private Instant startedAt;
+
+    @org.hibernate.annotations.UpdateTimestamp
+    @Column(nullable=false)
+    private Instant updatedAt;
+
+    /** 낙관적 락 버전 필드 → 동시 업데이트 충돌 시 예외로 감지 */
+    @Version
+    private Long version;
+
+    /** 외부에서 강제로 갱신 타임스탬프를 새기고 싶을 때 사용 */
+    public void touch() { this.updatedAt = Instant.now(); }
+}

--- a/src/main/java/com/project/saga/domain/domain/repository/OutboxRepository.java
+++ b/src/main/java/com/project/saga/domain/domain/repository/OutboxRepository.java
@@ -1,0 +1,34 @@
+package com.project.saga.domain.domain.repository;
+
+import com.project.saga.domain.domain.entity.OutboxEvent;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.data.repository.query.Param;
+import java.util.List;
+
+/**
+ * Outbox 퍼블리셔가 READY 이벤트를 락으로 안전하게 "가져가기" 위한 쿼리 제공.
+ *
+ * - FOR UPDATE SKIP LOCKED: 다중 퍼블리셔(스케줄러 컨커런시 등)에서도
+ *   서로 다른 레코드를 집어가도록 보장.
+ * - next_attempt_at <= 현재(UTC) 인 것만 집음 → backoff 대기 중 이벤트는 건너뜀.
+ * - 정렬: next_attempt_at, id 순으로 가장 오래 대기한 이벤트부터 전송.
+ */
+public interface OutboxRepository extends JpaRepository<OutboxEvent, Long> {
+
+    @Query(value = """
+      SELECT * FROM outbox_event
+      WHERE status='READY' AND next_attempt_at <= UTC_TIMESTAMP(3)
+      ORDER BY next_attempt_at, id
+      LIMIT :batch
+      FOR UPDATE SKIP LOCKED
+      """, nativeQuery = true)
+    List<OutboxEvent> lockBatchForSend(@Param("batch") int batch);
+
+    /** 동일 (eventId, eventType) 중복 전송 방지(멱등 체크)용 존재 여부 */
+    boolean existsByEventIdAndEventType(String eventId, String eventType);
+}
+
+// 운영 ddl 인덱스
+//CREATE INDEX idx_outbox_ready_next ON outbox_event(status, next_attempt_at, id);
+//CREATE UNIQUE INDEX ux_outbox_event ON outbox_event(event_id, event_type);
+//CREATE INDEX idx_saga_status_updated ON user_deletion_saga(status, updated_at, id);

--- a/src/main/java/com/project/saga/domain/domain/repository/UserDeletionSagaRepository.java
+++ b/src/main/java/com/project/saga/domain/domain/repository/UserDeletionSagaRepository.java
@@ -1,0 +1,20 @@
+package com.project.saga.domain.domain.repository;
+
+import com.project.saga.domain.domain.entity.UserDeletionSaga;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.time.Instant;
+import java.util.*;
+
+/** 사가 조회 및 타임아웃 스캔용 쿼리 제공 */
+public interface UserDeletionSagaRepository extends JpaRepository<UserDeletionSaga, Long> {
+
+    /** correlationId 기반 단건 조회(멱등 체크 포함 다수 지점에서 사용) */
+    Optional<UserDeletionSaga> findBySagaId(String sagaId);
+
+    /**
+     * IN_PROGRESS 상태인데 updated_at 이 오래된(=응답이 안 온) 사가 상위 N건.
+     * 타임아웃 보상 워커(DeletionTimeoutWatcher)가 주기적으로 조회.
+     */
+    List<UserDeletionSaga> findTop200ByStatusAndUpdatedAtBeforeOrderByIdAsc(
+            UserDeletionSaga.SagaStatus status, Instant before);
+}

--- a/src/main/java/com/project/saga/domain/domain/service/UserDeletionOrchestrator.java
+++ b/src/main/java/com/project/saga/domain/domain/service/UserDeletionOrchestrator.java
@@ -14,7 +14,7 @@ import java.time.Instant;
 /**
  * 유저 삭제 사가 오케스트레이터.
  *
- * - 시작 이벤트(user.deletion.start)를 받아 사가 레코드를 생성하고
+ * - 시작 이벤트(user.start-delete.command)를 받아 사가 레코드를 생성하고
  *   AUTH_REVOKE → SLEEP_DELETE 두 outbox 이벤트를 차례로 적재한다.
  * - 실제 브로커 전송은 OutboxPublisher 가 담당(Outbox 패턴).
  * - 동일 sagaId 반복 수신 시 멱등 처리로 무시한다.

--- a/src/main/java/com/project/saga/domain/domain/service/UserDeletionOrchestrator.java
+++ b/src/main/java/com/project/saga/domain/domain/service/UserDeletionOrchestrator.java
@@ -1,0 +1,67 @@
+package com.project.saga.domain.domain.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.saga.domain.domain.entity.OutboxEvent;
+import com.project.saga.domain.domain.entity.UserDeletionSaga;
+import com.project.saga.domain.domain.repository.OutboxRepository;
+import com.project.saga.domain.domain.repository.UserDeletionSagaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+
+/**
+ * 유저 삭제 사가 오케스트레이터.
+ *
+ * - 시작 이벤트(user.deletion.start)를 받아 사가 레코드를 생성하고
+ *   AUTH_REVOKE → SLEEP_DELETE 두 outbox 이벤트를 차례로 적재한다.
+ * - 실제 브로커 전송은 OutboxPublisher 가 담당(Outbox 패턴).
+ * - 동일 sagaId 반복 수신 시 멱등 처리로 무시한다.
+ */
+@Service @RequiredArgsConstructor
+public class UserDeletionOrchestrator {
+
+    private final UserDeletionSagaRepository sagaRepo;
+    private final OutboxRepository outboxRepo;
+    private final ObjectMapper om;
+
+    @Transactional
+    public void startWithSagaId(String sagaId, Long userNo, String accessToken, long blacklistSeconds){
+        // ✅ 멱등성: 동일 sagaId가 이미 있으면 무시(중복 시작 방지)
+        if (sagaRepo.findBySagaId(sagaId).isPresent()) return;
+
+        // 사가 생성(IN_PROGRESS/타임스탬프/버전은 엔티티 어노테이션으로 자동 세팅)
+        var saga = UserDeletionSaga.builder()
+                .sagaId(sagaId)
+                .userNo(userNo)
+                .build();
+        sagaRepo.save(saga);
+
+        // 1) 토큰 폐기(회신 없음 → 즉시 tokenOk=true)
+        outboxRepo.save(OutboxEvent.of(
+                sagaId, "User", userNo, "AUTH_REVOKE",
+                json(new AuthCmd(userNo, accessToken, blacklistSeconds)),
+                String.valueOf(userNo)
+        ));
+        saga.setTokenOk(true); saga.touch();
+
+        // 2) 슬립 삭제 커맨드 (reply 필요)
+        outboxRepo.save(OutboxEvent.of(
+                sagaId, "User", userNo, "SLEEP_DELETE",
+                json(new SleepCmd(userNo, sagaId)),
+                String.valueOf(userNo)
+        ));
+    }
+
+    /** 객체 → JSON 직렬화 헬퍼(실패 시 런타임 예외로 승격) */
+    private String json(Object o){
+        try { return om.writeValueAsString(o); } catch (Exception e){ throw new IllegalStateException(e); }
+    }
+
+    /** AUTH_REVOKE 페이로드 스키마 */
+    public record AuthCmd(Long userNo, String accessToken, long blacklistSeconds) {}
+
+    /** SLEEP_DELETE / SLEEP_COMPENSATE 페이로드 스키마(이벤트 상관을 위해 eventId 포함) */
+    public record SleepCmd(Long userNo, String eventId) {}
+}

--- a/src/main/java/com/project/saga/domain/infra/kafka/DeletionStartListener.java
+++ b/src/main/java/com/project/saga/domain/infra/kafka/DeletionStartListener.java
@@ -1,0 +1,79 @@
+package com.project.saga.domain.infra.kafka;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.saga.domain.domain.service.UserDeletionOrchestrator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.annotation.RetryableTopic;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * user.deletion.start 컨슈머.
+ *
+ * - API(유저 서비스)에서 발행한 사가 시작 이벤트를 수신하여 오케스트레이션을 트리거.
+ * - 파싱 실패/DB 제약 등 예외는 @RetryableTopic 으로 재시도→DLT 로 안전하게 흘린다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DeletionStartListener {
+
+    private final ObjectMapper om;
+    private final UserDeletionOrchestrator orchestrator;
+
+    @RetryableTopic(
+            attempts = "5",
+            backoff = @Backoff(delay = 1000, multiplier = 2.0), // 1s→2s→4s→8s→16s
+            autoCreateTopics = "true",
+            dltTopicSuffix = ".dlt"
+    )
+    @KafkaListener(topics = "user.deletion.start", groupId = "orchestrator")
+    @Transactional
+    public void onStart(
+            @Header(name = KafkaHeaders.RECEIVED_KEY, required = false) String key,
+            @Payload String payload
+    ) {
+        log.info("[orchestrator] start key={}, payload={}", key, payload);
+        try {
+            var n = om.readTree(payload);
+            String sagaId = n.path("sagaId").asText();
+            long   userNo = n.path("userNo").asLong();
+            String token  = n.path("accessToken").asText(null);
+            long   ttlSec = n.path("accessTokenTtlSec").asLong(0);
+
+            orchestrator.startWithSagaId(sagaId, userNo, token, ttlSec);
+        } catch (Exception e) {
+            // 예외를 리스루 → @RetryableTopic 가 재시도/보류/최종 DLT 로 처리
+            log.error("[orchestrator] onStart failed. payload={}", payload, e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    /** 시작 이벤트의 DLT 모니터링(운영 파악용 로그) */
+    @KafkaListener(topics = "user.deletion.start.dlt", groupId = "orchestrator")
+    public void onStartDlt(
+            @Payload String payload,
+            @Header(name = KafkaHeaders.RECEIVED_KEY, required = false) String key,
+            // 표준 DLT 헤더
+            @Header(name = KafkaHeaders.DLT_EXCEPTION_FQCN, required = false) String exFqcn,
+            @Header(name = KafkaHeaders.DLT_EXCEPTION_MESSAGE, required = false) String exMsg,
+            @Header(name = KafkaHeaders.DLT_EXCEPTION_STACKTRACE, required = false) String exStack,
+            // 구버전/대체 헤더
+            @Header(name = "kafka_exception-fqcn", required = false) String exFqcnRaw,
+            @Header(name = "kafka_exception-message", required = false) String exMsgRaw,
+            @Header(name = "kafka_exception-stacktrace", required = false) String exStackRaw
+    ) {
+        String msg = exMsg != null ? exMsg : exMsgRaw;
+        String fqcn = exFqcn != null ? exFqcn : exFqcnRaw;
+        String stack = exStack != null ? exStack : exStackRaw;
+
+        log.error("[DLT][user.deletion.start] key={}, exFqcn={}, exMsg={}\npayload={}\nstack={}",
+                key, fqcn, msg, payload, stack);
+    }
+}

--- a/src/main/java/com/project/saga/domain/infra/kafka/DeletionStartListener.java
+++ b/src/main/java/com/project/saga/domain/infra/kafka/DeletionStartListener.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * user.deletion.start 컨슈머.
+ * user.start-delete.command 컨슈머.
  *
  * - API(유저 서비스)에서 발행한 사가 시작 이벤트를 수신하여 오케스트레이션을 트리거.
  * - 파싱 실패/DB 제약 등 예외는 @RetryableTopic 으로 재시도→DLT 로 안전하게 흘린다.
@@ -28,12 +28,12 @@ public class DeletionStartListener {
     private final UserDeletionOrchestrator orchestrator;
 
     @RetryableTopic(
-            attempts = "5",
+            attempts = "3",
             backoff = @Backoff(delay = 1000, multiplier = 2.0), // 1s→2s→4s→8s→16s
-            autoCreateTopics = "true",
+            autoCreateTopics = "false",
             dltTopicSuffix = ".dlt"
     )
-    @KafkaListener(topics = "user.deletion.start", groupId = "orchestrator")
+    @KafkaListener(topics = "user.start-delete.command", groupId = "orchestrator")
     @Transactional
     public void onStart(
             @Header(name = KafkaHeaders.RECEIVED_KEY, required = false) String key,
@@ -56,7 +56,7 @@ public class DeletionStartListener {
     }
 
     /** 시작 이벤트의 DLT 모니터링(운영 파악용 로그) */
-    @KafkaListener(topics = "user.deletion.start.dlt", groupId = "orchestrator")
+    @KafkaListener(topics = "user.start-delete.command.dlt", groupId = "orchestrator")
     public void onStartDlt(
             @Payload String payload,
             @Header(name = KafkaHeaders.RECEIVED_KEY, required = false) String key,
@@ -73,7 +73,7 @@ public class DeletionStartListener {
         String fqcn = exFqcn != null ? exFqcn : exFqcnRaw;
         String stack = exStack != null ? exStack : exStackRaw;
 
-        log.error("[DLT][user.deletion.start] key={}, exFqcn={}, exMsg={}\npayload={}\nstack={}",
+        log.error("[DLT][user.start-delete.command] key={}, exFqcn={}, exMsg={}\npayload={}\nstack={}",
                 key, fqcn, msg, payload, stack);
     }
 }

--- a/src/main/java/com/project/saga/domain/infra/kafka/DeletionTimeoutWatcher.java
+++ b/src/main/java/com/project/saga/domain/infra/kafka/DeletionTimeoutWatcher.java
@@ -1,0 +1,55 @@
+package com.project.saga.domain.infra.kafka;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.saga.domain.domain.entity.OutboxEvent;
+import com.project.saga.domain.domain.entity.UserDeletionSaga;
+import com.project.saga.domain.domain.repository.OutboxRepository;
+import com.project.saga.domain.domain.repository.UserDeletionSagaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * 사가 타임아웃 감시자:
+ * - IN_PROGRESS 상태가 너무 오래 머물러 있으면 SLEEP_COMPENSATE 를 발행하여 복구.
+ * - 보상 자체도 Outbox 로 적재 → 퍼블리셔가 카프카로 전송.
+ */
+@Service @RequiredArgsConstructor
+public class DeletionTimeoutWatcher {
+
+    private final UserDeletionSagaRepository sagaRepo;
+    private final OutboxRepository outboxRepo;
+    private final ObjectMapper om;
+
+    /** IN_PROGRESS 허용 시간(초). 초과 시 보상 전환 */
+    @Value("${saga.delete.pending-ttl-sec:180}")
+    private long pendingTtlSec;
+
+    @Scheduled(fixedDelayString = "${saga.delete.timeout-scan-ms:30000}")
+    @Transactional
+    public void scanAndCompensate(){
+        Instant cutoff = Instant.now().minusSeconds(pendingTtlSec);
+
+        // 오래된 진행중 사가 상위 200건만 처리(폭주 방지)
+        var stuck = sagaRepo.findTop200ByStatusAndUpdatedAtBeforeOrderByIdAsc(
+                UserDeletionSaga.SagaStatus.IN_PROGRESS, cutoff);
+
+        for (var s : stuck){
+            s.setStatus(UserDeletionSaga.SagaStatus.COMPENSATING);
+            s.touch();
+            outboxRepo.save(OutboxEvent.of(
+                    s.getSagaId(), "User", s.getUserNo(), "SLEEP_COMPENSATE",
+                    json(om.createObjectNode().put("eventId", s.getSagaId()).put("userNo", s.getUserNo())),
+                    String.valueOf(s.getUserNo())
+            ));
+        }
+    }
+
+    private String json(Object o){
+        try { return om.writeValueAsString(o); } catch (Exception e){ throw new IllegalStateException(e); }
+    }
+}

--- a/src/main/java/com/project/saga/domain/infra/kafka/DltLogger.java
+++ b/src/main/java/com/project/saga/domain/infra/kafka/DltLogger.java
@@ -1,0 +1,43 @@
+package com.project.saga.domain.infra.kafka;
+
+// 공통 유틸(선택): 헤더를 예쁘게 로깅하고, 카운터 증가
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DltLogger {
+
+    private final MeterRegistry meter; // micrometer
+
+    public void logAndCount(
+            String dltTopic,
+            ConsumerRecord<String, String> rec,
+            @Header(name = KafkaHeaders.DLT_ORIGINAL_TOPIC, required = false)   String oTopic,
+            @Header(name = KafkaHeaders.DLT_ORIGINAL_PARTITION, required = false) Integer oPart,
+            @Header(name = KafkaHeaders.DLT_ORIGINAL_OFFSET, required = false)   Long oOffset,
+            @Header(name = KafkaHeaders.DLT_EXCEPTION_FQCN, required = false)    String exClass,
+            @Header(name = KafkaHeaders.DLT_EXCEPTION_MESSAGE, required = false) String exMsg
+    ) {
+        // 메트릭: dlt 카운트
+        meter.counter("kafka.dlt.count",
+                        "dltTopic", dltTopic,
+                        "origTopic", String.valueOf(oTopic))
+                .increment();
+
+        log.error("[DLT] topic={}, origTopic={}, origPartition={}, origOffset={}, key={}, ts={}, exClass={}, exMsg={}, payload={}",
+                dltTopic,
+                oTopic, oPart, oOffset,
+                rec.key(),
+                rec.timestamp(),
+                exClass, exMsg,
+                rec.value()
+        );
+    }
+}

--- a/src/main/java/com/project/saga/domain/infra/kafka/OrchestratorDltListeners.java
+++ b/src/main/java/com/project/saga/domain/infra/kafka/OrchestratorDltListeners.java
@@ -1,0 +1,51 @@
+package com.project.saga.domain.infra.kafka;
+import lombok.RequiredArgsConstructor;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OrchestratorDltListeners {
+
+    private final DltLogger dlt;
+
+    @KafkaListener(topics = "sleep.user-delete.reply.dlt", groupId = "orchestrator")
+    public void onSleepReplyDlt(
+            ConsumerRecord<String,String> rec,
+            @Header(name = KafkaHeaders.DLT_ORIGINAL_TOPIC, required = false)   String oTopic,
+            @Header(name = KafkaHeaders.DLT_ORIGINAL_PARTITION, required = false) Integer oPart,
+            @Header(name = KafkaHeaders.DLT_ORIGINAL_OFFSET, required = false)   Long oOffset,
+            @Header(name = KafkaHeaders.DLT_EXCEPTION_FQCN, required = false)    String exClass,
+            @Header(name = KafkaHeaders.DLT_EXCEPTION_MESSAGE, required = false) String exMsg
+    ){
+        dlt.logAndCount("sleep.user-delete.reply.dlt", rec, oTopic, oPart, oOffset, exClass, exMsg);
+    }
+
+    @KafkaListener(topics = "user.final-delete.reply.dlt", groupId = "orchestrator")
+    public void onUserFinalReplyDlt(
+            ConsumerRecord<String,String> rec,
+            @Header(name = KafkaHeaders.DLT_ORIGINAL_TOPIC, required = false)   String oTopic,
+            @Header(name = KafkaHeaders.DLT_ORIGINAL_PARTITION, required = false) Integer oPart,
+            @Header(name = KafkaHeaders.DLT_ORIGINAL_OFFSET, required = false)   Long oOffset,
+            @Header(name = KafkaHeaders.DLT_EXCEPTION_FQCN, required = false)    String exClass,
+            @Header(name = KafkaHeaders.DLT_EXCEPTION_MESSAGE, required = false) String exMsg
+    ){
+        dlt.logAndCount("user.final-delete.reply.dlt", rec, oTopic, oPart, oOffset, exClass, exMsg);
+    }
+
+    // (선택) 사가 시작 커맨드 DLT도 오케스트레이터가 본다면 여기에 추가
+    @KafkaListener(topics = "user.start-delete.command.dlt", groupId = "orchestrator")
+    public void onStartDeleteCmdDlt(
+            ConsumerRecord<String,String> rec,
+            @Header(name = KafkaHeaders.DLT_ORIGINAL_TOPIC, required = false)   String oTopic,
+            @Header(name = KafkaHeaders.DLT_ORIGINAL_PARTITION, required = false) Integer oPart,
+            @Header(name = KafkaHeaders.DLT_ORIGINAL_OFFSET, required = false)   Long oOffset,
+            @Header(name = KafkaHeaders.DLT_EXCEPTION_FQCN, required = false)    String exClass,
+            @Header(name = KafkaHeaders.DLT_EXCEPTION_MESSAGE, required = false) String exMsg
+    ){
+        dlt.logAndCount("user.start-delete.command.dlt", rec, oTopic, oPart, oOffset, exClass, exMsg);
+    }
+}

--- a/src/main/java/com/project/saga/domain/infra/kafka/OutboxPublisher.java
+++ b/src/main/java/com/project/saga/domain/infra/kafka/OutboxPublisher.java
@@ -1,0 +1,32 @@
+package com.project.saga.domain.infra.kafka;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+/**
+ * Outbox → Kafka 퍼블리셔(폴링형).
+ *
+ * - 1초 간격으로 READY + next_attempt_at 만료 레코드를 가져와 브로커 전송.
+ * - 너무 많은 레코드를 한 턴에서 처리하면 다른 스케줄러가 굶을 수 있어
+ *   MAX_PER_TICK 로 상한을 둔다(스레드풀/스케줄러 공정성).
+ */
+@Service @RequiredArgsConstructor
+public class OutboxPublisher {
+    private static final int BATCH = 100;         // DB에서 한 번에 집어올 수
+    private static final int MAX_PER_TICK = 5000; // 한 턴 최대 처리량(굶김 방지)
+    private final OutboxPublisherTx tx;
+
+    @Scheduled(fixedDelayString = "${outbox.poll.delay-ms:1000}")
+    public void publishOutbox() {
+        int total = 0;
+        while (total < MAX_PER_TICK) {
+            int n = tx.publishOnceTx(BATCH);
+            if (n == 0) break; // 더 없으면 조기 종료
+            total += n;
+        }
+        if (total > 0) {
+            // 필요 시 metrics/logging
+        }
+    }
+}

--- a/src/main/java/com/project/saga/domain/infra/kafka/OutboxPublisherTx.java
+++ b/src/main/java/com/project/saga/domain/infra/kafka/OutboxPublisherTx.java
@@ -1,0 +1,49 @@
+package com.project.saga.domain.infra.kafka;
+
+import com.project.saga.domain.domain.repository.OutboxRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import jakarta.transaction.Transactional;
+
+import java.time.Duration;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * 퍼블리셔의 트랜잭션 경계:
+ * - lockBatchForSend 로 락을 잡아 배치를 가져오고, 각 이벤트를 브로커로 동기 전송.
+ * - 성공하면 SENT 로 마킹, 실패하면 지수 백오프 + 지터로 nextAttemptAt 조정.
+ */
+@Service @RequiredArgsConstructor
+public class OutboxPublisherTx {
+    private final OutboxRepository repo;
+    private final ResilientSender sender;
+
+    @Transactional
+    public int publishOnceTx(int batchSize){
+        var batch = repo.lockBatchForSend(batchSize);
+        for (var e : batch){
+            try {
+                // eventType → 카프카 토픽 매핑(변경 시 여기를 수정)
+                String topic = switch (e.getEventType()){
+                    case "AUTH_REVOKE"       -> "auth.token.revoke";
+                    case "SLEEP_DELETE"      -> "user.delete.command";
+                    case "SLEEP_COMPENSATE"  -> "user.delete.compensate";
+                    case "USER_FINAL_DELETE" -> "user.final.delete";
+                    default -> throw new IllegalArgumentException("unknown eventType=" + e.getEventType());
+                };
+                sender.sendSync(topic, e.getPartitionKey(), e.getPayload());
+                e.markSent(); // 성공
+            } catch (Exception ex){
+                e.failAndBackoff(nextBackoff(e.getAttempts())); // 실패 → backoff
+            }
+        }
+        return batch.size();
+    }
+
+    /** 1,2,4,8,16,32,60s + 250~750ms 지터(최대 60s 캡) */
+    private Duration nextBackoff(int attempts){
+        long sec = Math.min(60, 1L << Math.min(attempts, 6));
+        long jitterMs = ThreadLocalRandom.current().nextLong(250, 750);
+        return Duration.ofSeconds(sec).plusMillis(jitterMs);
+    }
+}

--- a/src/main/java/com/project/saga/domain/infra/kafka/OutboxPublisherTx.java
+++ b/src/main/java/com/project/saga/domain/infra/kafka/OutboxPublisherTx.java
@@ -25,10 +25,10 @@ public class OutboxPublisherTx {
             try {
                 // eventType → 카프카 토픽 매핑(변경 시 여기를 수정)
                 String topic = switch (e.getEventType()){
-                    case "AUTH_REVOKE"       -> "auth.token.revoke";
-                    case "SLEEP_DELETE"      -> "user.delete.command";
-                    case "SLEEP_COMPENSATE"  -> "user.delete.compensate";
-                    case "USER_FINAL_DELETE" -> "user.final.delete";
+                    case "AUTH_REVOKE"       -> "auth.token-delete.command";
+                    case "SLEEP_DELETE"      -> "sleep.user-delete.command";
+                    case "SLEEP_COMPENSATE"  -> "sleep.user-delete.compensate.command";
+                    case "USER_FINAL_DELETE" -> "user.final-delete.command";
                     default -> throw new IllegalArgumentException("unknown eventType=" + e.getEventType());
                 };
                 sender.sendSync(topic, e.getPartitionKey(), e.getPayload());

--- a/src/main/java/com/project/saga/domain/infra/kafka/ResilientSender.java
+++ b/src/main/java/com/project/saga/domain/infra/kafka/ResilientSender.java
@@ -1,0 +1,28 @@
+package com.project.saga.domain.infra.kafka;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+import io.github.resilience4j.retry.annotation.Retry;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+
+/**
+ * 카프카 전송 래퍼:
+ * - .get() 호출로 브로커 acks=all 까지 동기 확인(실패 시 예외 발생)
+ * - Resilience4j @Retry/@CircuitBreaker 로 일시 장애 완충
+ *   (Fallback 은 재던져서 Outbox 백오프로 연결)
+ */
+@Component @RequiredArgsConstructor
+public class ResilientSender {
+    private final KafkaTemplate<String,String> kafka;
+
+    @Retry(name="kafkaSend")
+    @CircuitBreaker(name="kafkaSend", fallbackMethod = "sendFallback")
+    public void sendSync(String topic, String key, String payload) throws Exception {
+        kafka.send(topic, key, payload).get(); // 동기 전송
+    }
+    @SuppressWarnings("unused")
+    public void sendFallback(String topic, String key, String payload, Throwable t) throws Exception {
+        throw (t instanceof Exception) ? (Exception)t : new RuntimeException(t);
+    }
+}

--- a/src/main/java/com/project/saga/domain/infra/kafka/SleepReplyListener.java
+++ b/src/main/java/com/project/saga/domain/infra/kafka/SleepReplyListener.java
@@ -1,0 +1,99 @@
+package com.project.saga.domain.infra.kafka;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.saga.domain.domain.entity.OutboxEvent;
+import com.project.saga.domain.domain.entity.UserDeletionSaga;
+import com.project.saga.domain.domain.repository.OutboxRepository;
+import com.project.saga.domain.domain.repository.UserDeletionSagaRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.annotation.RetryableTopic;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 슬립 서비스의 삭제/보상 결과 회신(user.delete.reply) 처리.
+ *
+ * - SUCCESS/DELETE → sleepOk=true, 조건 충족 시 USER_FINAL_DELETE outbox 적재
+ * - FAIL          → COMPENSATING 으로 전환하고 SLEEP_COMPENSATE outbox 적재
+ * - SUCCESS/COMPENSATE → COMPENSATED 로 표기
+ *
+ * 주의:
+ * - 과거(시작 실패 등)로 인해 사가 레코드가 없을 수 있는데,
+ *   현재 코드는 orElseThrow 로 DLT 로 보냄. 운영에서 reply-만 도착하는
+ *   희귀 케이스를 “무해하게 스킵”하려면 Optional 가드로 바꾸는 것을 권장(TODO).
+ */
+@Slf4j
+@Component @RequiredArgsConstructor
+public class SleepReplyListener {
+
+    private final ObjectMapper om;
+    private final UserDeletionSagaRepository sagaRepo;
+    private final OutboxRepository outboxRepo;
+
+    @RetryableTopic(
+            attempts = "5",
+            backoff = @Backoff(delay = 1000, multiplier = 2.0),
+            autoCreateTopics = "true", dltTopicSuffix = ".dlt"
+    )
+    @KafkaListener(topics = "user.delete.reply", groupId = "orchestrator")
+    @Transactional
+    public void onSleepReply(String payload) throws Exception {
+        var n = om.readTree(payload);
+        String status = n.path("status").asText();                 // SUCCESS / FAIL ...
+        String type   = n.path("type").asText("DELETE").toUpperCase(); // DELETE / COMPENSATE
+        String sagaId = n.path("eventId").asText();
+        long userNo   = n.path("userNo").asLong();
+
+        var saga = sagaRepo.findBySagaId(sagaId).orElseThrow();    // TODO: Optional 가드로 변경 고려
+
+        if (!"SUCCESS".equalsIgnoreCase(status)) {
+            // 실패 → 보상 트리거 (이미 COMPENSATING이면 중복 방지)
+            if (saga.getStatus() != UserDeletionSaga.SagaStatus.COMPENSATING) {
+                saga.setStatus(UserDeletionSaga.SagaStatus.COMPENSATING);
+                saga.touch();
+                outboxRepo.save(OutboxEvent.of(
+                        sagaId, "User", userNo, "SLEEP_COMPENSATE",
+                        om.writeValueAsString(om.createObjectNode()
+                                .put("eventId", sagaId).put("userNo", userNo)),
+                        String.valueOf(userNo)
+                ));
+            }
+            return;
+        }
+
+        if ("COMPENSATE".equals(type)) {
+            // 보상 성공 마킹
+            saga.setStatus(UserDeletionSaga.SagaStatus.COMPENSATED);
+            saga.touch();
+            return;
+        }
+
+        if (!"DELETE".equals(type)) return; // 관심 없는 타입은 무시
+
+        // 슬립 삭제 성공(멱등 보정)
+        if (!saga.isSleepOk()) {
+            saga.setSleepOk(true);
+            saga.touch();
+        }
+
+        // 모든 선행조건 충족 시 유저 최종 삭제 커맨드 발행(중복 방지 체크)
+        if (saga.isTokenOk() && saga.isSleepOk() && !saga.isUserOk()
+                && !outboxRepo.existsByEventIdAndEventType(sagaId, "USER_FINAL_DELETE")) {
+            outboxRepo.save(OutboxEvent.of(
+                    sagaId, "User", userNo, "USER_FINAL_DELETE",
+                    om.writeValueAsString(om.createObjectNode()
+                            .put("eventId", sagaId).put("userNo", userNo)),
+                    String.valueOf(userNo)
+            ));
+        }
+    }
+
+    /** reply 의 DLT 모니터링(운영 파악용 로그) */
+    @KafkaListener(topics="user.delete.reply.dlt", groupId="orchestrator")
+    public void onSleepReplyDlt(String payload){
+        log.error("[DLT][sleep.reply] {}", payload);
+    }
+}

--- a/src/main/java/com/project/saga/domain/infra/kafka/SleepReplyListener.java
+++ b/src/main/java/com/project/saga/domain/infra/kafka/SleepReplyListener.java
@@ -14,19 +14,21 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * 슬립 서비스의 삭제/보상 결과 회신(user.delete.reply) 처리.
+ * 슬립 서비스의 삭제/보상 결과 회신(sleep.user-delete.reply) 처리.
  *
- * - SUCCESS/DELETE → sleepOk=true, 조건 충족 시 USER_FINAL_DELETE outbox 적재
- * - FAIL          → COMPENSATING 으로 전환하고 SLEEP_COMPENSATE outbox 적재
- * - SUCCESS/COMPENSATE → COMPENSATED 로 표기
+ * 규칙
+ * - SUCCESS / type=DELETE      → sleepOk=true, 조건 충족 시 USER_FINAL_DELETE 발행
+ * - SUCCESS / type=COMPENSATE  → COMPENSATED 로 표기(보상 성공)
+ * - FAIL    / type=DELETE      → (최초 1회) COMPENSATING 전환 + SLEEP_COMPENSATE 발행
+ * - FAIL    / type=COMPENSATE  → FAILED 로 종결(보상 자체가 실패 → 더 이상 진행 불가)
  *
- * 주의:
- * - 과거(시작 실패 등)로 인해 사가 레코드가 없을 수 있는데,
- *   현재 코드는 orElseThrow 로 DLT 로 보냄. 운영에서 reply-만 도착하는
- *   희귀 케이스를 “무해하게 스킵”하려면 Optional 가드로 바꾸는 것을 권장(TODO).
+ * 주의
+ * - 사가 레코드가 없으면 운영에서는 무해 스킵하는 편이 안전하지만,
+ *   현재는 orElseThrow 로 두어 데이터/플로우 문제를 조기에 드러내도록 함.
  */
 @Slf4j
-@Component @RequiredArgsConstructor
+@Component
+@RequiredArgsConstructor
 public class SleepReplyListener {
 
     private final ObjectMapper om;
@@ -34,66 +36,82 @@ public class SleepReplyListener {
     private final OutboxRepository outboxRepo;
 
     @RetryableTopic(
-            attempts = "5",
+            attempts = "3",
             backoff = @Backoff(delay = 1000, multiplier = 2.0),
-            autoCreateTopics = "true", dltTopicSuffix = ".dlt"
+            autoCreateTopics = "false",
+            dltTopicSuffix = ".dlt"
     )
-    @KafkaListener(topics = "user.delete.reply", groupId = "orchestrator")
+    @KafkaListener(topics = "sleep.user-delete.reply", groupId = "orchestrator")
     @Transactional
     public void onSleepReply(String payload) throws Exception {
         var n = om.readTree(payload);
-        String status = n.path("status").asText();                 // SUCCESS / FAIL ...
-        String type   = n.path("type").asText("DELETE").toUpperCase(); // DELETE / COMPENSATE
+        String status = n.path("status").asText();                    // SUCCESS | FAIL
+        String type   = n.path("type").asText("DELETE").toUpperCase();// DELETE | COMPENSATE
         String sagaId = n.path("eventId").asText();
         long userNo   = n.path("userNo").asLong();
 
-        var saga = sagaRepo.findBySagaId(sagaId).orElseThrow();    // TODO: Optional 가드로 변경 고려
+        var saga = sagaRepo.findBySagaId(sagaId).orElseThrow();
 
+        // ---- FAIL 경로 ----
         if (!"SUCCESS".equalsIgnoreCase(status)) {
-            // 실패 → 보상 트리거 (이미 COMPENSATING이면 중복 방지)
+            if ("COMPENSATE".equals(type)) {
+                // 보상도 실패 → 더 이상 할 게 없음. 사가를 FAILED 로 종결
+                saga.setStatus(UserDeletionSaga.SagaStatus.FAILED);
+                saga.touch();
+                log.warn("[orchestrator] sleep FAIL/COMPENSATE -> mark FAILED. sagaId={}, userNo={}", sagaId, userNo);
+                return;
+            }
+
+            // DELETE 실패: 최초 1회만 보상 트리거
             if (saga.getStatus() != UserDeletionSaga.SagaStatus.COMPENSATING) {
                 saga.setStatus(UserDeletionSaga.SagaStatus.COMPENSATING);
                 saga.touch();
-                outboxRepo.save(OutboxEvent.of(
-                        sagaId, "User", userNo, "SLEEP_COMPENSATE",
-                        om.writeValueAsString(om.createObjectNode()
-                                .put("eventId", sagaId).put("userNo", userNo)),
-                        String.valueOf(userNo)
-                ));
+                if (!outboxRepo.existsByEventIdAndEventType(sagaId, "SLEEP_COMPENSATE")) {
+                    outboxRepo.save(OutboxEvent.of(
+                            sagaId, "User", userNo, "SLEEP_COMPENSATE",
+                            om.writeValueAsString(om.createObjectNode()
+                                    .put("eventId", sagaId).put("userNo", userNo)),
+                            String.valueOf(userNo)
+                    ));
+                }
+                log.warn("[orchestrator] sleep FAIL/DELETE -> trigger COMPENSATE. sagaId={}, userNo={}", sagaId, userNo);
             }
             return;
         }
 
+        // ---- SUCCESS 경로 ----
         if ("COMPENSATE".equals(type)) {
-            // 보상 성공 마킹
+            // 보상 성공
             saga.setStatus(UserDeletionSaga.SagaStatus.COMPENSATED);
             saga.touch();
+            log.info("[orchestrator] sleep SUCCESS/COMPENSATE -> COMPENSATED. sagaId={}, userNo={}", sagaId, userNo);
             return;
         }
 
-        if (!"DELETE".equals(type)) return; // 관심 없는 타입은 무시
+        if (!"DELETE".equals(type)) {
+            // 우리가 관심 없는 타입이면 무해 스킵
+            log.debug("[orchestrator] ignore sleep reply type={}, sagaId={}", type, sagaId);
+            return;
+        }
 
-        // 슬립 삭제 성공(멱등 보정)
+        // DELETE 성공: 멱등 보정
         if (!saga.isSleepOk()) {
             saga.setSleepOk(true);
             saga.touch();
         }
 
-        // 모든 선행조건 충족 시 유저 최종 삭제 커맨드 발행(중복 방지 체크)
+        // 토큰/슬립 완료 & 아직 유저 최종 미발행이면 USER_FINAL_DELETE 커맨드 발행
         if (saga.isTokenOk() && saga.isSleepOk() && !saga.isUserOk()
                 && !outboxRepo.existsByEventIdAndEventType(sagaId, "USER_FINAL_DELETE")) {
+
             outboxRepo.save(OutboxEvent.of(
                     sagaId, "User", userNo, "USER_FINAL_DELETE",
                     om.writeValueAsString(om.createObjectNode()
                             .put("eventId", sagaId).put("userNo", userNo)),
                     String.valueOf(userNo)
             ));
+            log.info("[orchestrator] emit USER_FINAL_DELETE. sagaId={}, userNo={}", sagaId, userNo);
         }
     }
 
-    /** reply 의 DLT 모니터링(운영 파악용 로그) */
-    @KafkaListener(topics="user.delete.reply.dlt", groupId="orchestrator")
-    public void onSleepReplyDlt(String payload){
-        log.error("[DLT][sleep.reply] {}", payload);
-    }
 }

--- a/src/main/java/com/project/saga/domain/infra/kafka/UserFinalReplyListener.java
+++ b/src/main/java/com/project/saga/domain/infra/kafka/UserFinalReplyListener.java
@@ -1,0 +1,56 @@
+package com.project.saga.domain.infra.kafka;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.saga.domain.domain.entity.UserDeletionSaga;
+import com.project.saga.domain.domain.repository.UserDeletionSagaRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.annotation.RetryableTopic;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 유저 서비스의 최종 삭제 결과 회신(user.final.reply) 처리.
+ *
+ * - SUCCESS → userOk=true, (sleepOk도 true면) COMPLETED 로 사가 종료
+ * - FAIL    → FAILED 로 표기(타임아웃 워처/운영 수동 개입 고려)
+ */
+@Slf4j
+@Component @RequiredArgsConstructor
+public class UserFinalReplyListener {
+
+    private final ObjectMapper om;
+    private final UserDeletionSagaRepository sagaRepo;
+
+    @RetryableTopic(
+            attempts="5", backoff=@Backoff(delay=1000, multiplier=2.0),
+            autoCreateTopics="true", dltTopicSuffix=".dlt"
+    )
+    @KafkaListener(topics="user.final.reply", groupId="orchestrator")
+    @Transactional
+    public void onUserFinalReply(String payload) throws Exception {
+        var n = om.readTree(payload);
+        String status = n.path("status").asText();
+        String sagaId = n.path("eventId").asText();
+
+        var saga = sagaRepo.findBySagaId(sagaId).orElseThrow(); // (필요 시 Optional 가드 적용 가능)
+
+        if ("SUCCESS".equalsIgnoreCase(status)) {
+            if (!saga.isUserOk()) saga.setUserOk(true);
+            // 슬립이 이미 OK면 사가 종료
+            if (saga.isSleepOk()) saga.setStatus(UserDeletionSaga.SagaStatus.COMPLETED);
+            saga.touch();
+        } else {
+            saga.setStatus(UserDeletionSaga.SagaStatus.FAILED);
+            saga.touch();
+        }
+    }
+
+    /** 최종 삭제 reply 의 DLT 모니터링(운영 파악용 로그) */
+    @KafkaListener(topics="user.final.reply.dlt", groupId="orchestrator")
+    public void onUserFinalReplyDlt(String payload){
+        log.error("[DLT][user.final.reply] {}", payload);
+    }
+}

--- a/src/main/java/com/project/saga/domain/infra/kafka/UserFinalReplyListener.java
+++ b/src/main/java/com/project/saga/domain/infra/kafka/UserFinalReplyListener.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * 유저 서비스의 최종 삭제 결과 회신(user.final.reply) 처리.
+ * 유저 서비스의 최종 삭제 결과 회신(user.final-delete.reply) 처리.
  *
  * - SUCCESS → userOk=true, (sleepOk도 true면) COMPLETED 로 사가 종료
  * - FAIL    → FAILED 로 표기(타임아웃 워처/운영 수동 개입 고려)
@@ -25,10 +25,10 @@ public class UserFinalReplyListener {
     private final UserDeletionSagaRepository sagaRepo;
 
     @RetryableTopic(
-            attempts="5", backoff=@Backoff(delay=1000, multiplier=2.0),
-            autoCreateTopics="true", dltTopicSuffix=".dlt"
+            attempts="3", backoff=@Backoff(delay=1000, multiplier=2.0),
+            autoCreateTopics="false", dltTopicSuffix=".dlt"
     )
-    @KafkaListener(topics="user.final.reply", groupId="orchestrator")
+    @KafkaListener(topics="user.final-delete.reply", groupId="orchestrator")
     @Transactional
     public void onUserFinalReply(String payload) throws Exception {
         var n = om.readTree(payload);
@@ -48,9 +48,5 @@ public class UserFinalReplyListener {
         }
     }
 
-    /** 최종 삭제 reply 의 DLT 모니터링(운영 파악용 로그) */
-    @KafkaListener(topics="user.final.reply.dlt", groupId="orchestrator")
-    public void onUserFinalReplyDlt(String payload){
-        log.error("[DLT][user.final.reply] {}", payload);
-    }
+
 }

--- a/src/main/java/com/project/saga/global/config/KafkaConfig.java
+++ b/src/main/java/com/project/saga/global/config/KafkaConfig.java
@@ -1,0 +1,73 @@
+package com.project.saga.global.config;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.context.annotation.*;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.*;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+import java.util.*;
+
+@Configuration
+@EnableKafka
+public class KafkaConfig {
+
+    @Bean
+    public ProducerFactory<String,String> producerFactory(KafkaProperties props){
+        Map<String,Object> cfg = new HashMap<>(props.buildProducerProperties());
+        cfg.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        cfg.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        cfg.put(ProducerConfig.ACKS_CONFIG, "all");
+        cfg.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
+        cfg.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 1);
+        return new DefaultKafkaProducerFactory<>(cfg);
+    }
+    @Bean
+    public KafkaTemplate<String,String> kafkaTemplate(ProducerFactory<String,String> pf){
+        return new KafkaTemplate<>(pf);
+    }
+
+    @Bean
+    public ConsumerFactory<String,String> consumerFactory(KafkaProperties props){
+        Map<String,Object> cfg = new HashMap<>(props.buildConsumerProperties());
+        cfg.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        cfg.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        cfg.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        cfg.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
+        return new DefaultKafkaConsumerFactory<>(cfg);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String,String> kafkaListenerContainerFactory(
+            ConsumerFactory<String,String> cf){
+        var f = new ConcurrentKafkaListenerContainerFactory<String,String>();
+        f.setConsumerFactory(cf);
+        f.getContainerProperties().setAckMode(ContainerProperties.AckMode.BATCH);
+        return f;
+    }
+    @Bean(name="kafkaManualAckFactory")
+    public ConcurrentKafkaListenerContainerFactory<String,String> kafkaManualAckFactory(
+            ConsumerFactory<String,String> cf){
+        var f = new ConcurrentKafkaListenerContainerFactory<String,String>();
+        f.setConsumerFactory(cf);
+        f.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL_IMMEDIATE);
+        f.setConcurrency(3);
+        return f;
+    }
+
+    // @RetryableTopic이 요구하는 스케줄러
+    @Bean
+    public org.springframework.scheduling.TaskScheduler taskScheduler(){
+        var t = new ThreadPoolTaskScheduler();
+        t.setPoolSize(2);
+        t.setThreadNamePrefix("orch-sched-");
+        t.initialize();
+        return t;
+    }
+}

--- a/src/main/java/com/project/saga/global/config/KafkaConfig.java
+++ b/src/main/java/com/project/saga/global/config/KafkaConfig.java
@@ -23,9 +23,9 @@ public class KafkaConfig {
         Map<String,Object> cfg = new HashMap<>(props.buildProducerProperties());
         cfg.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         cfg.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
-        cfg.put(ProducerConfig.ACKS_CONFIG, "all");
-        cfg.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
-        cfg.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 1);
+//        cfg.put(ProducerConfig.ACKS_CONFIG, "all");
+//        cfg.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
+//        cfg.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 1);
         return new DefaultKafkaProducerFactory<>(cfg);
     }
     @Bean
@@ -38,7 +38,7 @@ public class KafkaConfig {
         Map<String,Object> cfg = new HashMap<>(props.buildConsumerProperties());
         cfg.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         cfg.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        cfg.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        cfg.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest"); // 클라우드
         cfg.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
         return new DefaultKafkaConsumerFactory<>(cfg);
     }
@@ -57,7 +57,7 @@ public class KafkaConfig {
         var f = new ConcurrentKafkaListenerContainerFactory<String,String>();
         f.setConsumerFactory(cf);
         f.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL_IMMEDIATE);
-        f.setConcurrency(3);
+        //f.setConcurrency(3);
         return f;
     }
 

--- a/src/main/java/com/project/saga/global/config/SqlIndexInitializerConfig.java
+++ b/src/main/java/com/project/saga/global/config/SqlIndexInitializerConfig.java
@@ -1,0 +1,76 @@
+package com.project.saga.global.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import jakarta.annotation.PostConstruct;
+
+/**
+ * 부트 시점에 운영 인덱스를 보증한다.
+ *
+ * 대상/효과
+ * - outbox_event:
+ *    1) idx_outbox_ready_next(status, next_attempt_at, id) : 폴링/정렬 쿼리 최적화
+ *    2) ux_outbox_event(event_id, event_type) UNIQUE      : 동일 이벤트 중복 방지
+ * - user_deletion_saga:
+ *    3) idx_saga_status_updated(status, updated_at, id)   : 타임아웃 스캐너 쿼리 최적화
+ *    4) ux_saga_saga_id(saga_id) UNIQUE                   : 사가Id 단일성 보증(코드에도 unique)
+ *
+ * 주의
+ * - 앱 DB 계정에 CREATE INDEX 권한 필요.
+ * - 운영에선 Flyway/Liquibase 권장. 필요 시 해당 마이그레이션으로 대체 가능.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SqlIndexInitializerConfig {
+
+    private final JdbcTemplate jdbc;
+
+    @PostConstruct
+    public void ensureIndexes() {
+        // 현재 스키마명 획득
+        String schema = jdbc.queryForObject("SELECT DATABASE()", String.class);
+
+        // ---- outbox_event ----
+        ensure(schema, "outbox_event", "idx_outbox_ready_next",
+                "CREATE INDEX idx_outbox_ready_next " +
+                        "ON `outbox_event` (`status`, `next_attempt_at`, `id`)");
+
+        ensure(schema, "outbox_event", "ux_outbox_event",
+                "CREATE UNIQUE INDEX ux_outbox_event " +
+                        "ON `outbox_event` (`event_id`, `event_type`)");
+
+        // ---- user_deletion_saga ----
+        ensure(schema, "user_deletion_saga", "idx_saga_status_updated",
+                "CREATE INDEX idx_saga_status_updated " +
+                        "ON `user_deletion_saga` (`status`, `updated_at`, `id`)");
+
+        // 엔티티에 unique가 잡혀 있어도 스키마에 없을 수 있으니 보증
+        ensure(schema, "user_deletion_saga", "ux_saga_saga_id",
+                "CREATE UNIQUE INDEX ux_saga_saga_id " +
+                        "ON `user_deletion_saga` (`saga_id`)");
+    }
+
+    /** index 존재 여부 확인 후 없으면 생성 */
+    private void ensure(String schema, String table, String indexName, String createDdl) {
+        Integer exists = jdbc.queryForObject(
+                """
+                SELECT COUNT(*) 
+                  FROM information_schema.statistics 
+                 WHERE table_schema = ? 
+                   AND table_name   = ? 
+                   AND index_name   = ?
+                """,
+                Integer.class, schema, table, indexName
+        );
+        if (exists != null && exists > 0) {
+            log.info("[index] exists: {}.{} -> skip", table, indexName);
+            return;
+        }
+        jdbc.execute(createDdl);
+        log.info("[index] created: {}.{}", table, indexName);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,32 @@
 server:
   port: 8080
 
+resilience4j:
+  retry:
+    instances:
+      kafkaSend:
+        max-attempts: 3
+        wait-duration: 200ms
+        enable-exponential-backoff: true
+        exponential-backoff-multiplier: 2
+        retry-exceptions:
+          - org.apache.kafka.common.errors.TimeoutException
+          - org.apache.kafka.common.errors.RetriableException
+  circuitbreaker:
+    instances:
+      kafkaSend:
+        sliding-window-type: count_based
+        sliding-window-size: 20
+        failure-rate-threshold: 50
+        wait-duration-in-open-state: 10s
+        permitted-number-of-calls-in-half-open-state: 3
+        automatic-transition-from-open-to-half-open-enabled: true
+
 spring:
+  kafka:
+    bootstrap-servers: ${SPRING_KAFKA_BOOTSTRAP_SERVERS:localhost:9094} # 컨테이너 내부에선 kafka:9092 로 env로만 덮어쓰기
+    admin:
+      fail-fast: true
   datasource:
     username: ${RDB_USERNAME}
     url: ${RDB_URL}
@@ -20,7 +45,7 @@ logging:
     org.springframework: DEBUG
     org.springframework.web: DEBUG
     org.springframework.boot: DEBUG
-    com.project.user: DEBUG
+    com.project.saga: DEBUG
     org.hibernate.SQL: DEBUG
     org.hibernate.type.descriptor.sql: TRACE
 
@@ -38,7 +63,7 @@ management:
       enabled: true
   metrics:
     tags:
-      application: user-service
+      application: orchestrator-service
     distribution:
       percentiles-histogram:
         http.server.requests: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,9 +24,28 @@ resilience4j:
 
 spring:
   kafka:
-    bootstrap-servers: ${SPRING_KAFKA_BOOTSTRAP_SERVERS:localhost:9094} # 컨테이너 내부에선 kafka:9092 로 env로만 덮어쓰기
+    bootstrap-servers: pkc-gq2xn.asia-northeast3.gcp.confluent.cloud:9092
+    properties:
+      security.protocol: SASL_SSL
+      sasl.mechanism: PLAIN
+      sasl.jaas.config: >
+        org.apache.kafka.common.security.plain.PlainLoginModule required
+        username="AGQDVMNB6DVPXFX7"
+        password="cfltBaumbQnzwuPIRS3E8S1MNrfqrsb9LXzDvUBPBrP0YQRUTfBqdD2nOKmzUXFw";
+    producer:
+      acks: all
+      retries: 3
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+    consumer:
+      enable-auto-commit: false
+      auto-offset-reset: latest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
     admin:
+      auto-create: false
       fail-fast: true
+
   datasource:
     username: ${RDB_USERNAME}
     url: ${RDB_URL}


### PR DESCRIPTION
## 📌 관련 이슈
- #1 
## ✨ 변경 사항
- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요.
    - 회원 탈퇴로 인한 서비스 전파
    - yml 파일 일부 수정

## ✅ 체크리스트
- [x] 코드 스타일 가이드 준수
- [x] 로컬에서 정상 동작 확인
- [ ] 관련 테스트 추가/수정 완료
- [ ] 문서화 필요 시 업데이트 완료

## 📸 스크린샷 (선택)
<img width="1403" height="189" alt="image" src="https://github.com/user-attachments/assets/da8cbbc9-d3e1-44e6-a6a5-ce16a6ac1726" />
<img width="833" height="166" alt="image" src="https://github.com/user-attachments/assets/526c7acc-016b-4990-922c-4320cd4a08ed" />
<img width="1159" height="172" alt="image" src="https://github.com/user-attachments/assets/ffbbc0b8-5ac6-4dea-bb65-e765e3d88003" />


## 📢 기타 참고 사항
- 카프카 토픽 리스트를 아래 적어뒀습니다.
- 세부 의문사항은 유저서비스쪽에 적어뒀습니다
woongjae@HanWoongJaeui-MacBookPro kea % docker compose exec kafka rpk topic list                               

WARN[0000] /Users/woongjae/Desktop/kea/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
NAME                               PARTITIONS  REPLICAS
auth.token.revoke                  1           1
auth.token.revoke-retry-1000       1           1
auth.token.revoke-retry-2000       1           1
auth.token.revoke-retry-4000       1           1
auth.token.revoke-retry-8000       1           1
auth.token.revoke.dlt              1           1
user.delete.command                1           1
user.delete.command-retry-1000     1           1
user.delete.command-retry-2000     1           1
user.delete.command-retry-4000     1           1
user.delete.command-retry-8000     1           1
user.delete.command.dlt            1           1
user.delete.compensate             1           1
user.delete.compensate-retry-1000  1           1
user.delete.compensate-retry-2000  1           1
user.delete.compensate-retry-4000  1           1
user.delete.compensate-retry-8000  1           1
user.delete.compensate.dlt         1           1
user.delete.reply                  1           1
user.delete.reply-retry-1000       1           1
user.delete.reply-retry-2000       1           1
user.delete.reply-retry-4000       1           1
user.delete.reply-retry-8000       1           1
user.delete.reply.dlt              1           1
user.deletion.start                1           1
user.deletion.start-retry-1000     1           1
user.deletion.start-retry-2000     1           1
user.deletion.start-retry-4000     1           1
user.deletion.start-retry-8000     1           1
user.deletion.start.dlt            1           1
user.final.delete                  1           1
user.final.delete-retry-1000       1           1
user.final.delete-retry-2000       1           1
user.final.delete-retry-4000       1           1
user.final.delete-retry-8000       1           1
user.final.delete.dlt              1           1
user.final.reply                   1           1
user.final.reply-retry-1000        1           1
user.final.reply-retry-2000        1           1
user.final.reply-retry-4000        1           1
user.final.reply-retry-8000        1           1
user.final.reply.dlt               1           1

그리고 지피티가 생성한 제 사가 플로우를 아래 넣었습니다. 양이 넘 많아서 양해..
한눈에 요약
	•	사용자 호출 → user-service의 /api/users (DELETE)
	•	검증 → 비밀번호 일치 + JWT 파싱
	•	사가 시작 → Kafka user.deletion.start 발행
	•	오케스트레이터 → 사가 row 생성 + Outbox에 2건 적재
	•	AUTH_REVOKE (토큰 블랙리스트), SLEEP_DELETE (수면데이터 삭제)
	•	Outbox 퍼블리셔 → Kafka로 발행
	•	auth-service → 액세스 토큰을 남은 TTL만큼 블랙리스트, 리프레시 토큰 즉시 삭제
	•	sleep-service → Mongo에서 유저 데이터 아카이브 후 본삭제, 성공 reply
	•	오케스트레이터 → 둘 다 OK면 USER_FINAL_DELETE 발행
	•	user-service → MySQL users 하드 삭제, 성공 reply
	•	오케스트레이터 → COMPLETED로 사가 종료

실패/예외가 어딘가서 나면:
	•	Outbox 지수 백오프 재시도, Kafka 재시도/ DLT, **사가 타임아웃 보상(SLEEP_COMPENSATE)**로 복구 시도

⸻

디테일 플로우

0) 호출/검증 (user-service)
	1.	클라이언트가 Authorization: Bearer <accessToken> + body(비밀번호)로 호출.
	2.	DeleteAccountController → DeleteAccountUseCase
	•	TokenProvider.getId()로 userNo 추출
	•	비밀번호 검사 통과 (BCrypt)
	•	토큰 남은 유효시간(TTL, 초) 계산.
	3.	사가 시작 이벤트를 Kafka user.deletion.start로 동기 전송(acks=all, .get())
Payload 예:
{
  "sagaId": "UUID",
  "userNo": 7648...0983,
  "accessToken": "eyJ... ",
  "accessTokenTtlSec": 1234
}
1) 사가 시작 (saga-orchestration-service)
	4.	DeletionStartListener가 consume → UserDeletionOrchestrator.startWithSagaId(...)
	5.	user_deletion_saga에 한 건 insert (상태: IN_PROGRESS). 멱등: sagaId 중복 시 무시.
	6.	Outbox에 두 건 insert:
	•	AUTH_REVOKE: {"userNo", "accessToken", "blacklistSeconds": ttlSec}
	•	SLEEP_DELETE: {"eventId": sagaId, "userNo"}
→ partitionKey = userNo 로 같은 유저 이벤트 순서 보장

2) Outbox → Kafka (퍼블리셔)
	7.	OutboxPublisher(1초마다) → OutboxPublisherTx.publishOnceTx()
	•	status=READY & next_attempt_at <= now를 락 잡아 배치 조회
	•	이벤트 타입별 토픽 맵핑:
	•	AUTH_REVOKE → auth.token.revoke
	•	SLEEP_DELETE → user.delete.command
	•	SLEEP_COMPENSATE → user.delete.compensate
	•	USER_FINAL_DELETE → user.final.delete
	•	전송 성공: SENT 마킹
	•	실패: failAndBackoff() → 1/2/4/8/16/32/60초 + 250~750ms 지터로 next_attempt_at 밀어두고 다시 READY

이 구조 때문에 퍼블리셔는 항상 1초마다 깨어나지만, 전송실패 레코드는 각자 next_attempt_at이 도래할 때만 재시도돼요. (백오프는 Outbox 레벨에서 이미 적용됨)

3) 토큰 폐기 (auth-service)
	8.	auth.token.revoke 수신(AuthRevokeListener)
	•	JSON 파싱 실패 등 독성 payload는 즉시 DLT
	•	액세스 토큰: blacklistSeconds > 0이면 Redis BLACKLIST:<token>에 TTL = 남은 유효시간으로 set
→ 그 토큰은 즉시 무력화(모든 API 거절)
	•	리프레시 토큰: deleteRefreshToken(userNo)로 즉시 삭제
	•	이 단계는 사가와 무관하게 항상 실행(Reply 없음). 오케스트레이터는 이미 tokenOk = true로 진척 마킹.

4) 슬립 데이터 삭제 (sleep-service)
	9.	user.delete.command 수신(UserDeletionConsumers.onDeleteCommand)
	•	멱등키(ProcessedEvent)로 중복 처리 방지
	•	트랜잭션으로: 모든 컬렉션을 *_archive로 복제(archiving) 후 원본 삭제
	•	성공 시 Kafka user.delete.reply에 { status: "SUCCESS", type: "DELETE" } 송신
	•	실패 시 예외 throw → Spring Kafka 재시도 → 한계 초과하면 .dlt로 이동
(FAIL reply는 보내지 않음)
	10.	SleepReplyListener가 성공 reply 수신
	•	sleepOk = true
	•	tokenOk && sleepOk && !userOk 이고 USER_FINAL_DELETE 미발행이면
Outbox에 USER_FINAL_DELETE insert (멱등 체크: existsByEventIdAndEventType)

만약 슬립 단계가 응답 없이 실패해 멈추면?
DeletionTimeoutWatcher가 IN_PROGRESS & 오래 갱신 안 된 사가를 주기적으로 스캔해 **보상 명령 SLEEP_COMPENSATE**를 Outbox에 넣습니다.

5) 최종 유저 삭제 (user-service)
	11.	user.final.delete 수신(UserFinalDeleteListener)
	•	멱등키(ProcessedEvent) 확인
	•	users 테이블에서 해당 userNo 하드 삭제 (idempotent)
	•	성공 시 user.final.reply에 {status: "SUCCESS"} 송신
→ ProcessedEvent 성공 마킹, 오프셋 ACK
	12.	UserFinalReplyListener가 성공 reply 수신
	•	userOk = true
	•	sleepOk도 이미 true라면 사가 상태를 COMPLETED 로 전이

⸻

실패/예외 시나리오 정리

A. Kafka 전송/브로커 이슈
	•	Outbox 퍼블리셔에서 예외 → 레코드별 지수 백오프로 재시도
	•	컨슈머 측 예외 → @RetryableTopic 으로 일정 횟수 재시도 후 DLT 토픽으로 이동
(DLT 리스너에서 원인/페이로드 로그)

B. 슬립 삭제 단계 실패
	•	런타임 에러로 reply 못 보냄 → user.delete.reply 없음
	•	오케스트레이터는 IN_PROGRESS로 대기하다가 TimeoutWatcher가 감지하여
SLEEP_COMPENSATE(복구) 발행 → sleep-service가 *_archive에서 원복 수행
	•	복구 성공 reply {status: "SUCCESS", type: "COMPENSATE"} → 사가 상태 COMPENSATED

C. 최종 유저 삭제 단계 실패
	•	예외 발생 시 컨슈머에서 재시도 → 그래도 안되면 .dlt
	•	성공 reply만 보내고, 실패 reply는 안 보냄 구조이므로, 최종 실패 시 오케스트레이터는 reply를 못 받아 대기 상태로 남을 수 있음
→ 일반적으로는 컨슈머 재시도로 복구되지만, 영구 실패라면 운영 개입(원인 제거 후 재처리 or 수동 보상) 필요
	•	(필요하면: 최종 단계도 타임아웃 감시를 추가해 FAILED 표기하거나 재트리거 전략을 넣을 수 있어요)

D. 토큰 관련
	•	auth-service의 블랙리스트/리프레시 삭제는 사가와 독립적으로 반드시 실행
	•	액세스 토큰은 남은 TTL 동안만 블랙리스트에 머무르며, 리프레시는 즉시 삭제 → 재로그인 필요
	•	유저가 실제 삭제되면, 새 로그인 자체가 다른 로직으로 막히므로 user-wide block은 미사용

E. 멱등/중복 방지 포인트
	•	오케스트레이터: sagaId로 중복 start 무시
	•	Outbox: (event_id, event_type) UNIQUE
	•	슬립/유저 컨슈머: processed_event 기반 중복 처리 방지
	•	최종 삭제 발행: existsByEventIdAndEventType로 중복 발행 방지
	•	파티션 키 userNo 고정 → 동일 유저 이벤트 순서 보장

⸻

상태 전이 (UserDeletionSaga)
	•	IN_PROGRESS (초기)
↓ 슬립 성공 + (토큰은 즉시 OK로 간주)
	•	COMPLETED (최종 유저 삭제 성공 reply 수신)
↘ (슬립 실패/정체) COMPENSATING → 슬립 복구 성공 → COMPENSATED
↘ (최종 삭제 오류 reply가 옵니다 라는 구조라면) FAILED  ※ 현재 코드는 실패 reply를 보내지 않으므로 주로 재시도/운영介入로 회복
